### PR TITLE
Update less.js

### DIFF
--- a/less.js
+++ b/less.js
@@ -109,7 +109,7 @@ console.log(' |________________________________________________________');
 console.log('');
 
 // file and directory watchers
-watch($watch, function (filename) {
+watch($watch, function (evt, filename) {
     if (path.extname(filename) == '.less') {
         fs.stat(filename, function (err, stat) {
             if (err !== null) return;


### PR DESCRIPTION
Fehlermeldung nach npm start
(node:25617) DeprecationWarning: (node-watch) First param in callback function  is replaced with event name since 0.5.0, use  `(evt, filename) => {}` if you want to get the filenameevt, filename